### PR TITLE
Fix script for users with a different home directory

### DIFF
--- a/platformio.ini/pokitto_pre.py
+++ b/platformio.ini/pokitto_pre.py
@@ -1,10 +1,11 @@
+Import("env")
+
 import requests
 import os
 import filecmp
 
-#the following is needed, because at this stage PLATFORMIO_HOME_DIR is undefined
-from os.path import expanduser
-home = expanduser("~")
+# Works even if the user has overrided PLATFORMIO_HOME_DIR
+home = env['PIOHOME_DIR']
 
 if os.name == 'nt': # Windows
     basePath = home + '\.platformio'


### PR DESCRIPTION
PlatformIO lets users set `PLATFORMIO_HOME_DIR` to override the default location of `.platformio`.
This change accounts for that and fixes the script so it works for those users.