### PR TITLE
Replace env lookup with more robust function

### DIFF
--- a/platformio.ini/pokitto_pre.py
+++ b/platformio.ini/pokitto_pre.py
@@ -3,9 +3,10 @@ Import("env")
 import requests
 import os
 import filecmp
+from platformio.project.helpers import get_project_core_dir
 
 # Works even if the user has overrided PLATFORMIO_HOME_DIR
-home = env['PIOHOME_DIR']
+home = get_project_core_dir()
 
 patchPath = home + '/packages/framework-mbed/targets/TARGET_NXP/TARGET_LPC11U6X/device/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/'
 
@@ -34,7 +35,7 @@ else:
 
 #delete temporary file(s)
 if (os.path.exists(patchPath + 'startup_LPC11U68.tmp')):
-    os.remove(patchPath+'startup_LPC11U68.tmp')
+    os.remove(patchPath +'startup_LPC11U68.tmp')
 
 #get the latest linker file from github
 print("Comparing linker file LPC11U68.ld to PokittoLib repository...")
@@ -62,4 +63,4 @@ else:
 
 #delete temporary file(s)
 if (os.path.exists(patchPath + 'LPC11U68.tmp')):
-    os.remove(patchPath+'LPC11U68.tmp')
+    os.remove(patchPath +'LPC11U68.tmp')


### PR DESCRIPTION
Apparently the old way was using an internal feature rather than the intented public API.
See platformio/platformio-core#2971 for more info.